### PR TITLE
Fix build issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ OBJ=$(patsubst %.cpp, %.o, $(SRC))
 
 all: $(OBJ)
 	@mkdir -p bin
-	$(CC) -o $(BIN) $(OBJ)
+	$(CC) $(FL) -o $(BIN) $(OBJ)
 
 %.o: %.cpp
-	$(CC) -c $(FL) $< -lstdc++ -o $@
+	$(CC) -c $(FL) $< -o $@
 
 clean:
 	rm -f $(OBJ)
-	rm $(BIN)
+	rm -f $(BIN)


### PR DESCRIPTION
## Summary
- fix linking flags in Makefile for clang++ and libc++
- remove unnecessary stdc++ dependency
- consistently use tabs for recipe lines
- clean target removes binary safely

## Testing
- `make -s`
- `ls -l bin`

------
https://chatgpt.com/codex/tasks/task_e_684a07b9584883318adca1c2601bd901